### PR TITLE
Make {{> oneCell}} an actual component

### DIFF
--- a/loopy.html
+++ b/loopy.html
@@ -9,11 +9,11 @@
 </body>
 
 <template name="oneCell">
-  <rect x="{{this.xPos}}"
-        y="{{this.yPos}}"
+  <rect x="{{xPos}}"
+        y="{{yPos}}"
         height=22
         width=22
-        class="cell {{#if this.active}}active{{/if}}" />
+        class="cell {{#if active}}active{{/if}}" />
 </template>
 
 <template name="hello">
@@ -37,10 +37,7 @@
   <div>
     <svg width="100%" height="20%" viewBox="0 0 800 130">
       {{#each cell in cells}}
-        {{> oneCell xPos=(xPos cell.time)
-                    yPos=(yPos cell.instrument)
-                    active=cell.active
-                    cellId=cell._id }}
+        {{> oneCell cell=cell}}
       {{/each}}
       <rect x="{{stepXPos}}" y="100" height="10" width="22" class="step" />
     </svg>

--- a/loopy.js
+++ b/loopy.js
@@ -63,7 +63,19 @@ if (Meteor.isClient) {
 
   Template.oneCell.events({
     "click rect": function () {
-      Meteor.call("toggleCell", this.cellId);
+      Meteor.call("toggleCell", this.cell._id);
+    }
+  });
+
+  Template.oneCell.helpers({
+    xPos: function () {
+      return this.cell.time * 25;
+    },
+    yPos: function () {
+      return this.cell.instrument * 25;
+    },
+    active: function() {
+      return this.cell.active;
     }
   });
 
@@ -88,12 +100,6 @@ if (Meteor.isClient) {
   Template.hello.helpers({
     cells: function () {
       return Cells.find();
-    },
-    xPos: function (time) {
-      return time * 25;
-    },
-    yPos: function (instrument) {
-      return instrument * 25;
     },
     playing: function () {
       return Session.get("playing");


### PR DESCRIPTION
Prior to this change, some of the logic of oneCell lived
in the template including it.

Now, oneCell takes a single argument which is a cell document
from the Cells Mongo collection.
