### PR TITLE
Remove unncessary clipping logic

### DIFF
--- a/loopy.js
+++ b/loopy.js
@@ -77,10 +77,6 @@ if (Meteor.isClient) {
     },
     "change .bpm": function (event) {
       var newBpm = parseInt(event.target.value, 10);
-
-      newBpm = Math.min(newBpm, 300);
-      newBpm = Math.max(newBpm, 20);
-
       Session.set("bpm", newBpm);
     }
   });


### PR DESCRIPTION
Probably left-over from a previous version of the app where
setting BPM was done via a "number" input box
